### PR TITLE
:Color for modify current color, and keep format

### DIFF
--- a/plugin/colorx.vim
+++ b/plugin/colorx.vim
@@ -77,7 +77,7 @@ function! s:parse_percent_val(val)
     let val = float2nr( str2float(val) * 2.55 )
     let val = max([0, val])
     let val = min([255, val])
-    return printf('%x', val)
+    return printf('%02x', val)
   else
     return a:val
   end

--- a/plugin/colorx.vim
+++ b/plugin/colorx.vim
@@ -56,7 +56,7 @@ function! s:parse_hex_color(colour)
       break
     end
   endwhile
-  return a:colour
+  return ['', col, col, '', '']
 endfunction
 
 " Convert dec value to HEX
@@ -166,7 +166,7 @@ function! s:parse_rgb_color(colour)
           endif
           return ['#' . cr . cg . cb . alpha, start, end, format, '']
         else
-          return ['']
+          return ['', col, col, '', '']
         end
         break
       end
@@ -207,7 +207,9 @@ function! s:parse_color()
     let colour[0] = printf('default color {%d,%d,%d}', cr, cg, cb)
     return colour
   endif
-  return ['']
+
+  let colour[0] = ''
+  return colour
 endfunction
 
 function! s:pick_colour(default)
@@ -225,15 +227,11 @@ endfunction
 function! s:replace_colour(col)
   let colour = a:col[0]
   if colour != '' 
-    if len(a:col) > 1
-      let start = a:col[1]
-      let end = a:col[2]
-      let line = getline('.')
-      let line = strpart(line, 0, start) . colour . strpart(line, end, len(line) - end)
-      call setline(line('.'), line)
-    else
-      exe "normal a" . colour
-    end
+    let start = a:col[1]
+    let end = a:col[2]
+    let line = getline('.')
+    let line = strpart(line, 0, start) . colour . strpart(line, end, len(line) - end)
+    call setline(line('.'), line)
   end
 endfunction
 

--- a/plugin/colorx.vim
+++ b/plugin/colorx.vim
@@ -39,12 +39,13 @@ function! s:parse_hex_color(colour)
   let line = getline('.')
   let col = col('.')
   let start_col = 0
+  let pattern = '#\([a-fA-F0-9]\{3,8\}\)'
   while 1
-    let start = match(line, '#\([a-fA-F0-9]\{3,6\}\)', start_col)
-    let end = matchend(line, '#\([a-fA-F0-9]\{3,6\}\)', start_col)
+    let start = match(line, pattern, start_col)
+    let end = matchend(line, pattern, start_col)
     if start > -1
       if col >= start + 1 && col <= end
-        return [matchstr(line, '#\([a-fA-F0-9]\{3,6\}\)', start_col), start, end]
+        return [matchstr(line, pattern, start_col), start, end]
         break
       end
       let start_col = end
@@ -56,16 +57,18 @@ function! s:parse_hex_color(colour)
 endfunction
 
 function! s:parse_dec_val(val)
-  let val = a:val
-  if val =~ '^[12]\?[0-9]\{1,2\}$'
-    return printf('%02x', str2nr(val, 10))
+  if a:val =~ '^-\?[12]\?[0-9]\{1,2\}$'
+    let val = str2nr(a:val, 10)
+    let val = max([0, val])
+    let val = min([255, val])
+    return printf('%02x', val)
   else
     return a:val
   end
 endfunction
 
 function! s:parse_percent_val(val)
-  if a:val =~ '^[0-9\.]\+%$'
+  if a:val =~ '^-\?[0-9\.]\+%$'
     let val = strpart(a:val, 0, len(a:val) - 1)
     let val = float2nr( str2float(val) * 2.55 )
     let val = max([0, val])
@@ -97,7 +100,7 @@ function! s:parse_rgb_color(colour)
   let line = getline('.')
   let col = col('.')
   let start_col = 0
-  let pattern = '\crgba\?([0-9 ,\.%]\+)'
+  let pattern = '\crgba\?([0-9 ,\-\.%]\+)'
   while 1
     let start = match(line, pattern, start_col)
     let end = matchend(line, pattern, start_col)
@@ -134,7 +137,7 @@ function! s:parse_html_color()
   let colour = s:parse_rgb_color(colour)
   let w = colour[0]
 
-  if w =~ '#\([a-fA-F0-9]\{3,6\}\)'
+  if w =~ '#\([a-fA-F0-9]\{3,8\}\)'
     let offset = 2
     let mult = 256
     if len(w) == 4 || len(w) == 5

--- a/plugin/colorx.vim
+++ b/plugin/colorx.vim
@@ -31,6 +31,7 @@ let s:ascrpt = ['-e "tell application \"' . g:colorpicker_app . '\""',
       \ ') as text"',
       \ '-e "end tell"']
 
+" Get cursor color in HEX format
 function! s:parse_hex_color(colour)
   if a:colour[0] != ''
     return a:colour
@@ -56,6 +57,7 @@ function! s:parse_hex_color(colour)
   return a:colour
 endfunction
 
+" Convert dec value to HEX
 function! s:parse_dec_val(val)
   if a:val =~ '^-\?[12]\?[0-9]\{1,2\}$'
     let val = str2nr(a:val, 10)
@@ -67,6 +69,8 @@ function! s:parse_dec_val(val)
   end
 endfunction
 
+" Convert percent value to HEX
+" return [color, start, end]
 function! s:parse_percent_val(val)
   if a:val =~ '^-\?[0-9\.]\+%$'
     let val = strpart(a:val, 0, len(a:val) - 1)
@@ -79,6 +83,7 @@ function! s:parse_percent_val(val)
   end
 endfunction
 
+" Conver RGB value to HEX
 function! s:parse_rgb_val(val)
   let val = a:val
   let val = substitute(val, '^ \+', '', '')
@@ -92,6 +97,8 @@ function! s:parse_rgb_val(val)
   end
 endfunction
 
+" Get cursor color in RGB[A] format
+" return [color, start, end]
 function! s:parse_rgb_color(colour)
   if a:colour[0] != ''
     return a:colour

--- a/plugin/colorx.vim
+++ b/plugin/colorx.vim
@@ -165,7 +165,7 @@ function! s:colour_rgb()
   let colour = s:parse_html_color()
   let result = system("osascript " . join(insert(s:ascrpt, colour[0], 4), ' '))
   if result =~ '[0-9]\+,[0-9]\+,[0-9]\+'
-    let colour[0] = result
+    let colour[0] = strpart(result, 0, len(result) - 1)
     return colour
   else
     return ['']

--- a/plugin/colorx.vim
+++ b/plugin/colorx.vim
@@ -208,7 +208,7 @@ function! s:parse_color()
     return colour
   endif
 
-  let colour[0] = ''
+  let colour[0] = printf('default color {%d,%d,%d}', 65535, 65535, 65535)
   return colour
 endfunction
 

--- a/plugin/colorx.vim
+++ b/plugin/colorx.vim
@@ -186,7 +186,7 @@ function! s:parse_color()
 
   if w =~ '#\([a-fA-F0-9]\{3,8\}\)'
     let offset = 2
-    let mult = 256
+    let mult = 255
     if len(w) < 7
       let offset = 1
       let mult = mult * 17
@@ -248,9 +248,9 @@ function! s:colour_hex(colour)
   else
     let rgb = split(colour[0], ',')
     if len(colour) > 1 && colour[4] != ''
-      let colour[0] = printf('#%02X%02X%02X%02X', str2nr(rgb[0])/256, str2nr(rgb[1])/256, str2nr(rgb[2])/256, str2nr(colour[4], 16))
+      let colour[0] = printf('#%02X%02X%02X%02X', str2nr(rgb[0])/255, str2nr(rgb[1])/255, str2nr(rgb[2])/255, str2nr(colour[4], 16))
     else
-      let colour[0] = printf('#%02X%02X%02X', str2nr(rgb[0])/256, str2nr(rgb[1])/256, str2nr(rgb[2])/256)
+      let colour[0] = printf('#%02X%02X%02X', str2nr(rgb[0])/255, str2nr(rgb[1])/255, str2nr(rgb[2])/255)
     endif
     return colour
   end
@@ -263,9 +263,9 @@ function! s:colour_rgbcss(colour)
   else
     let rgb = split(colour[0], ',')
     if len(colour) > 1 && colour[4] != ''
-      let colour[0] = printf('rgba(%d, %d, %d, %.2f)', str2nr(rgb[0])/256, str2nr(rgb[1])/256, str2nr(rgb[2])/256, str2nr(colour[4], 16)/255.0)
+      let colour[0] = printf('rgba(%d, %d, %d, %.2f)', str2nr(rgb[0])/255, str2nr(rgb[1])/255, str2nr(rgb[2])/255, str2nr(colour[4], 16)/255.0)
     else
-      let colour[0] = printf('rgb(%d, %d, %d)', str2nr(rgb[0])/256, str2nr(rgb[1])/256, str2nr(rgb[2])/256)
+      let colour[0] = printf('rgb(%d, %d, %d)', str2nr(rgb[0])/255, str2nr(rgb[1])/255, str2nr(rgb[2])/255)
     endif
     return colour
   end
@@ -277,10 +277,13 @@ function! s:colour_rgbcss100(colour)
     return colour
   else
     let rgb = split(colour[0], ',')
+    let cr = round(str2nr(rgb[0])*100/65535.0)
+    let cg = round(str2nr(rgb[1])*100/65535.0)
+    let cb = round(str2nr(rgb[2])*100/65535.0)
     if len(colour) > 1 && colour[4] != ''
-      let colour[0] = printf('rgba(%d%%, %d%%, %d%%, %d%%)', str2nr(rgb[0])*100/65536, str2nr(rgb[1])*100/65536, str2nr(rgb[2])*100/65536, str2nr(colour[4], 16)*100/256)
+      let colour[0] = printf('rgba(%.0f%%, %.0f%%, %.0f%%, %.0f%%)', cr, cg, cb, round(str2nr(colour[4], 16)*100/255.0))
     else
-      let colour[0] = printf('rgb(%d%%, %d%%, %d%%)', str2nr(rgb[0])*100/65536, str2nr(rgb[1])*100/65536, str2nr(rgb[2])*100/65536)
+      let colour[0] = printf('rgb(%.0f%%, %.0f%%, %.0f%%)', str2nr(cr, cg, cb)
     endif
     return colour
   end


### PR DESCRIPTION
Add a new command `:Color`
This command will query current color and keep the format(`#fff` or `rgb()`).
If no color on current cursor position.
Then will use default format, which is HEX format.

It's a pity that applescript don't support alpha channel.
So what I can do is keep the value if I can get one.

2 new command also introduce:
- `:ColorRGBCSS`, will use `rgb(0, 100, 255)`
- `:ColorRGB100`, will use `rgb(0%, 10%, 100%)`

Other small fix included in this pull request are:
- Default color set to white
- Improve 255 <-> 65535 transform
- Code tuning
- Other minor bug fix

Might add HSL format support.
Studying how to transform it.
